### PR TITLE
feat: enable drag-drop field creation

### DIFF
--- a/src/app/modules/dynamic-form-builder/builder-state.service.ts
+++ b/src/app/modules/dynamic-form-builder/builder-state.service.ts
@@ -47,7 +47,7 @@ export class BuilderState {
     this.schema.set(s); this.persist();
   }
 
-  addField(kind: FieldConfig['type'], stepIndex?: number, sectionIndex?: number) {
+  addField(kind: FieldConfig['type'], stepIndex?: number, sectionIndex?: number, index?: number) {
     const s = structuredClone(this.schema());
     const f: FieldConfig =
       kind === 'textblock'
@@ -58,7 +58,9 @@ export class BuilderState {
       ? s.steps![stepIndex].sections![sectionIndex!]
       : s.sections![sectionIndex!];
 
-    (targetSection.fields ??= []).push(f);
+    (targetSection.fields ??= []);
+    const at = index ?? targetSection.fields.length;
+    targetSection.fields.splice(at, 0, f);
     this.schema.set(s); this.persist();
   }
 

--- a/src/app/modules/dynamic-form-builder/components/canvas/canvas.html
+++ b/src/app/modules/dynamic-form-builder/components/canvas/canvas.html
@@ -17,7 +17,7 @@
             <button nz-button size="small" (click)="$event.stopPropagation(); state.addField('text', si, secIdx)">+ Champ</button>
           </div>
 
-          <div class="fields" cdkDropList (cdkDropListDropped)="dropField(si, secIdx, $event)">
+          <div class="fields" cdkDropList [cdkDropListConnectedTo]="['palette']" (cdkDropListDropped)="dropField(si, secIdx, $event)">
             <div class="field" *ngFor="let f of sec.fields; let fi = index" cdkDrag (click)="state.selectField(fi, secIdx, si)">
               <code>{{ f.type }}</code> <span *ngIf="f.type!=='textblock'">• {{ f.key }}</span>
             </div>
@@ -39,7 +39,7 @@
         <button nz-button size="small" (click)="$event.stopPropagation(); state.addField('text', undefined, secIdx)">+ Champ</button>
       </div>
 
-      <div class="fields" cdkDropList (cdkDropListDropped)="dropField(undefined, secIdx, $event)">
+      <div class="fields" cdkDropList [cdkDropListConnectedTo]="['palette']" (cdkDropListDropped)="dropField(undefined, secIdx, $event)">
         <div class="field" *ngFor="let f of sec.fields; let fi = index" cdkDrag (click)="state.selectField(fi, secIdx)">
           <code>{{ f.type }}</code> <span *ngIf="f.type!=='textblock'">{{ f.key }}</span>
         </div>

--- a/src/app/modules/dynamic-form-builder/components/canvas/canvas.ts
+++ b/src/app/modules/dynamic-form-builder/components/canvas/canvas.ts
@@ -3,8 +3,9 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { NzListModule } from 'ng-zorro-antd/list';
 import { NzButtonModule } from 'ng-zorro-antd/button';
-import { DragDropModule, CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
+import { DragDropModule, CdkDragDrop } from '@angular/cdk/drag-drop';
 import { BuilderState } from '../../builder-state.service';
+import { FieldConfig } from '../../builder.types';
 
 @Component({
   selector: 'df-canvas',
@@ -26,6 +27,13 @@ export class Canvas {
     this.state.reorderSection(stepIndex, ev.previousIndex, ev.currentIndex);
   }
   dropField(stepIndex: number | undefined, sectionIndex: number, ev: CdkDragDrop<any[]>) {
-    this.state.reorderField(stepIndex, sectionIndex, ev.previousIndex, ev.currentIndex);
+    if (ev.previousContainer === ev.container) {
+      this.state.reorderField(stepIndex, sectionIndex, ev.previousIndex, ev.currentIndex);
+    } else {
+      const kind = ev.item.data as FieldConfig['type'];
+      if (kind) {
+        this.state.addField(kind, stepIndex, sectionIndex, ev.currentIndex);
+      }
+    }
   }
 }

--- a/src/app/modules/dynamic-form-builder/components/palette/palette.html
+++ b/src/app/modules/dynamic-form-builder/components/palette/palette.html
@@ -7,15 +7,15 @@
 
 <div class="group">
   <div class="title">Champs</div>
-  <div cdkDropListDisabled="true">
-    <button nz-button cdkDrag>Text</button>
-    <button nz-button cdkDrag>Textarea</button>
-    <button nz-button cdkDrag>Number</button>
-    <button nz-button cdkDrag>Date</button>
-    <button nz-button cdkDrag>Select</button>
-    <button nz-button cdkDrag>Radio</button>
-    <button nz-button cdkDrag>Checkbox</button>
-    <button nz-button cdkDrag>TextBlock</button>
+  <div cdkDropList id="palette" cdkDropListDisabled="true">
+    <button nz-button cdkDrag [cdkDragData]="'text'">Text</button>
+    <button nz-button cdkDrag [cdkDragData]="'textarea'">Textarea</button>
+    <button nz-button cdkDrag [cdkDragData]="'number'">Number</button>
+    <button nz-button cdkDrag [cdkDragData]="'date'">Date</button>
+    <button nz-button cdkDrag [cdkDragData]="'select'">Select</button>
+    <button nz-button cdkDrag [cdkDragData]="'radio'">Radio</button>
+    <button nz-button cdkDrag [cdkDragData]="'checkbox'">Checkbox</button>
+    <button nz-button cdkDrag [cdkDragData]="'textblock'">TextBlock</button>
   </div>
   <small>Astuce: tu peux aussi ajouter depuis l’inspecteur.</small>
 </div>


### PR DESCRIPTION
## Summary
- allow dragging field types from palette to canvas
- insert new fields at drop position in builder state
- wire canvas drop handling for new field creation

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_689b3d7dc398832fa55bc381ffea1427