### PR TITLE
feat: add dynamic form builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,7 @@ Angular CLI does not come with an end-to-end testing framework by default. You c
 ## Additional Resources
 
 For more information on using the Angular CLI, including detailed command references, visit the [Angular CLI Overview and Command Reference](https://angular.dev/tools/cli) page.
+
+## Dynamic Form Builder Demo
+
+Run the dev server and navigate to `http://localhost:4200/dynamic-form` to open a minimal drag and drop form builder. The builder lets you add/reorder steps, sections and fields, edit basic properties and preview the result with the DynamicForm component. Use the Import/Export buttons to load or dump the JSON schema.

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -28,6 +28,10 @@ export const routes: Routes = [
         component: LayoutBuilder,
         children: [
             {
+                path: 'dynamic-form',
+                loadComponent: () => import('./features/dynamic-form/dynamic-form-builder.component').then(m => m.DynamicFormBuilderComponent)
+            },
+            {
                 path: 'builder',
                 loadChildren: () =>
                     import('./features/builder/builder-module').then(m => m.BuilderModule)

--- a/src/app/features/dynamic-form/dynamic-form-builder.component.html
+++ b/src/app/features/dynamic-form/dynamic-form-builder.component.html
@@ -1,0 +1,84 @@
+<div class="builder">
+  <div class="controls">
+    <button nz-button nzType="default" (click)="addStep()">Add Step</button>
+  </div>
+  <div class="canvas" cdkDropList [cdkDropListData]="schema.steps || []" (cdkDropListDropped)="dropStep($event)">
+    <div class="step" *ngFor="let step of schema.steps; let si = index" cdkDrag (click)="select(step)">
+      <div class="step-header">{{ step.title || 'Step ' + (si + 1) }}</div>
+      <div class="sections" cdkDropList [cdkDropListData]="step.sections" (cdkDropListDropped)="dropSection($event, step)">
+        <div class="section" *ngFor="let section of step.sections" cdkDrag (click)="select(section)">
+          <div class="section-header">
+            {{ section.title || 'Section' }}
+            <button nz-button nzSize="small" (click)="addField(section); $event.stopPropagation()">+ Field</button>
+          </div>
+          <div class="fields" cdkDropList [cdkDropListData]="section.fields || []" (cdkDropListDropped)="dropField($event, section)">
+            <div class="field" *ngFor="let field of (section.fields || [])" cdkDrag (click)="select(field)">
+              {{ field.label || field.type }}
+            </div>
+          </div>
+        </div>
+        <button nz-button nzSize="small" (click)="addSection(step)">+ Section</button>
+      </div>
+    </div>
+  </div>
+  <div class="inspector" *ngIf="selected">
+    <form nz-form [formGroup]="inspector">
+      <nz-form-item>
+        <nz-form-label>Title</nz-form-label>
+        <nz-form-control>
+          <input nz-input formControlName="title" />
+        </nz-form-control>
+      </nz-form-item>
+      <nz-form-item>
+        <nz-form-label>Key</nz-form-label>
+        <nz-form-control>
+          <input nz-input formControlName="key" />
+        </nz-form-control>
+      </nz-form-item>
+      <nz-form-item>
+        <nz-form-label>Label</nz-form-label>
+        <nz-form-control>
+          <input nz-input formControlName="label" />
+        </nz-form-control>
+      </nz-form-item>
+      <nz-form-item>
+        <nz-form-label>Placeholder</nz-form-label>
+        <nz-form-control>
+          <input nz-input formControlName="placeholder" />
+        </nz-form-control>
+      </nz-form-item>
+      <nz-form-item>
+        <nz-form-label>Options</nz-form-label>
+        <nz-form-control>
+          <textarea nz-input formControlName="options"></textarea>
+        </nz-form-control>
+      </nz-form-item>
+      <nz-form-item>
+        <nz-form-label>visibleIf</nz-form-label>
+        <nz-form-control>
+          <textarea nz-input formControlName="visibleIf"></textarea>
+        </nz-form-control>
+      </nz-form-item>
+      <nz-form-item>
+        <nz-form-label>requiredIf</nz-form-label>
+        <nz-form-control>
+          <textarea nz-input formControlName="requiredIf"></textarea>
+        </nz-form-control>
+      </nz-form-item>
+      <nz-form-item>
+        <nz-form-label>disabledIf</nz-form-label>
+        <nz-form-control>
+          <textarea nz-input formControlName="disabledIf"></textarea>
+        </nz-form-control>
+      </nz-form-item>
+    </form>
+  </div>
+  <div class="preview">
+    <dynamic-form [schema]="schema"></dynamic-form>
+  </div>
+  <div class="io">
+    <textarea [(ngModel)]="json" [ngModelOptions]="{standalone: true}"></textarea>
+    <button nz-button nzType="default" (click)="import()">Import</button>
+    <button nz-button nzType="default" (click)="export()">Export</button>
+  </div>
+</div>

--- a/src/app/features/dynamic-form/dynamic-form-builder.component.scss
+++ b/src/app/features/dynamic-form/dynamic-form-builder.component.scss
@@ -1,0 +1,38 @@
+.builder {
+  display: flex;
+  gap: 16px;
+}
+.canvas {
+  flex: 1;
+  border: 1px dashed #ccc;
+  padding: 8px;
+}
+.inspector {
+  width: 300px;
+}
+.preview {
+  flex: 1;
+  border: 1px solid #eee;
+  padding: 8px;
+}
+.io {
+  margin-top: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+textarea {
+  width: 100%;
+  min-height: 100px;
+}
+.step, .section, .field {
+  border: 1px solid #ddd;
+  padding: 4px;
+  margin-bottom: 4px;
+  background: #fafafa;
+}
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}

--- a/src/app/features/dynamic-form/dynamic-form-builder.component.ts
+++ b/src/app/features/dynamic-form/dynamic-form-builder.component.ts
@@ -1,0 +1,121 @@
+import { CdkDragDrop, DragDropModule, moveItemInArray } from '@angular/cdk/drag-drop';
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+import { FormsModule, ReactiveFormsModule, FormBuilder, FormGroup } from '@angular/forms';
+import { NzButtonModule } from 'ng-zorro-antd/button';
+import { NzInputModule } from 'ng-zorro-antd/input';
+import { NzSelectModule } from 'ng-zorro-antd/select';
+import { NzFormModule } from 'ng-zorro-antd/form';
+import { NzCardModule } from 'ng-zorro-antd/card';
+import { DynamicFormComponent } from './dynamic-form.component';
+import { FieldConfig, FormSchema, SectionConfig, StepConfig } from './dynamic-form.types';
+
+@Component({
+  selector: 'dynamic-form-builder',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
+    DragDropModule,
+    NzButtonModule,
+    NzInputModule,
+    NzSelectModule,
+    NzFormModule,
+    NzCardModule,
+    DynamicFormComponent,
+  ],
+  templateUrl: './dynamic-form-builder.component.html',
+  styleUrl: './dynamic-form-builder.component.scss',
+})
+export class DynamicFormBuilderComponent {
+  schema: FormSchema = { steps: [] };
+  selected: StepConfig | SectionConfig | FieldConfig | null = null;
+  inspector!: FormGroup;
+  json = '';
+
+  constructor(private fb: FormBuilder) {
+    this.createInspector();
+  }
+
+  createInspector(): void {
+    this.inspector = this.fb.group({
+      title: [''],
+      key: [''],
+      label: [''],
+      placeholder: [''],
+      options: [''],
+      visibleIf: [''],
+      requiredIf: [''],
+      disabledIf: [''],
+    });
+    this.inspector.valueChanges.subscribe(v => {
+      if (this.selected) {
+        Object.assign(this.selected, {
+          title: v.title || undefined,
+          key: v.key || undefined,
+          label: v.label || undefined,
+          placeholder: v.placeholder || undefined,
+          options: v.options ? JSON.parse(v.options) : undefined,
+          visibleIf: v.visibleIf ? JSON.parse(v.visibleIf) : undefined,
+          requiredIf: v.requiredIf ? JSON.parse(v.requiredIf) : undefined,
+          disabledIf: v.disabledIf ? JSON.parse(v.disabledIf) : undefined,
+        });
+      }
+    });
+  }
+
+  select(obj: any): void {
+    this.selected = obj;
+    this.inspector.patchValue({
+      title: obj.title ?? '',
+      key: obj.key ?? '',
+      label: obj.label ?? '',
+      placeholder: obj.placeholder ?? '',
+      options: obj.options ? JSON.stringify(obj.options) : '',
+      visibleIf: obj.visibleIf ? JSON.stringify(obj.visibleIf) : '',
+      requiredIf: obj.requiredIf ? JSON.stringify(obj.requiredIf) : '',
+      disabledIf: obj.disabledIf ? JSON.stringify(obj.disabledIf) : '',
+    });
+  }
+
+  addStep(): void {
+    const step: StepConfig = { title: 'Step', sections: [] };
+    this.schema.steps = this.schema.steps ?? [];
+    this.schema.steps.push(step);
+  }
+
+  addSection(step: StepConfig): void {
+    step.sections.push({ title: 'Section', fields: [] });
+  }
+
+  addField(section: SectionConfig): void {
+    section.fields = section.fields ?? [];
+    section.fields.push({ type: 'text', key: 'field', label: 'Field' });
+  }
+
+  dropStep(event: CdkDragDrop<StepConfig[]>): void {
+    moveItemInArray(this.schema.steps!, event.previousIndex, event.currentIndex);
+  }
+
+  dropSection(event: CdkDragDrop<SectionConfig[]>, step: StepConfig): void {
+    moveItemInArray(step.sections, event.previousIndex, event.currentIndex);
+  }
+
+  dropField(event: CdkDragDrop<FieldConfig[]>, section: SectionConfig): void {
+    if (!section.fields) return;
+    moveItemInArray(section.fields, event.previousIndex, event.currentIndex);
+  }
+
+  export(): void {
+    this.json = JSON.stringify(this.schema, null, 2);
+  }
+
+  import(): void {
+    try {
+      this.schema = JSON.parse(this.json);
+    } catch {
+      alert('Invalid JSON');
+    }
+  }
+}

--- a/src/app/features/dynamic-form/dynamic-form.component.html
+++ b/src/app/features/dynamic-form/dynamic-form.component.html
@@ -1,0 +1,117 @@
+<form nz-form *ngIf="form" [formGroup]="form" [nzLayout]="schema?.ui?.layout ?? 'horizontal'" [nzLabelAlign]="schema?.ui?.labelAlign ?? 'left'" [style.width.px]="schema?.ui?.widthPx">
+  <nz-steps *ngIf="schema?.steps" [nzCurrent]="currentStep">
+    <nz-step *ngFor="let step of schema!.steps" [nzTitle]="step.title"></nz-step>
+    <nz-step *ngIf="schema?.summary?.enabled" [nzTitle]="schema?.summary?.title || 'Summary'"></nz-step>
+  </nz-steps>
+
+  <ng-container *ngIf="schema?.steps; else nonStepper">
+    <ng-container *ngFor="let step of schema!.steps; let si = index">
+      <div *ngIf="currentStep === si">
+        <ng-container *ngFor="let section of step.sections">
+          <div *ngIf="isVisible(section.visibleIf)" nz-row [nzGutter]="section.grid?.gutter ?? 0">
+            <ng-container *ngFor="let field of visibleFields(section)">
+              <div nz-col *ngIf="field.type !== 'textblock'; else textBlock">
+                <nz-form-item>
+                  <nz-form-label [nzSpan]="schema?.ui?.labelCol?.span ?? null" [nzOffset]="schema?.ui?.labelCol?.offset ?? null" [nzRequired]="field.validators?.includes(Validators.required)">{{ field.label }}</nz-form-label>
+                  <nz-form-control [nzSpan]="schema?.ui?.controlCol?.span ?? null" [nzOffset]="schema?.ui?.controlCol?.offset ?? null">
+                    <ng-container [ngSwitch]="field.type">
+                      <input *ngSwitchCase="'text'" nz-input [formControlName]="field.key!" [placeholder]="field.placeholder" />
+                      <textarea *ngSwitchCase="'textarea'" nz-input [formControlName]="field.key!" [placeholder]="field.placeholder"></textarea>
+                      <input *ngSwitchCase="'number'" nz-input type="number" [formControlName]="field.key!" [placeholder]="field.placeholder" />
+                      <nz-date-picker *ngSwitchCase="'date'" [formControlName]="field.key!" />
+                      <nz-select *ngSwitchCase="'select'" [formControlName]="field.key!">
+                        <nz-option *ngFor="let o of field.options" [nzLabel]="o.label" [nzValue]="o.value"></nz-option>
+                      </nz-select>
+                      <nz-radio-group *ngSwitchCase="'radio'" [formControlName]="field.key!">
+                        <label nz-radio *ngFor="let o of field.options" [nzValue]="o.value">{{ o.label }}</label>
+                      </nz-radio-group>
+                      <label *ngSwitchCase="'checkbox'" nz-checkbox [formControlName]="field.key!">{{ field.label }}</label>
+                    </ng-container>
+                    <div class="desc" *ngIf="field.description">{{ field.description }}</div>
+                  </nz-form-control>
+                </nz-form-item>
+              </div>
+              <ng-template #textBlock><div class="text-block" [innerHTML]="field.textHtml"></div></ng-template>
+            </ng-container>
+          </div>
+        </ng-container>
+      </div>
+    </ng-container>
+    <div *ngIf="schema?.summary?.enabled && currentStep === stepFieldKeys.length - 1">
+      <h3>{{ schema?.summary?.title || 'Summary' }}</h3>
+      <div *ngFor="let field of allFields()">
+        <div *ngIf="schema?.summary?.includeHidden || isVisible(field.visibleIf)">
+          <strong>{{ field.label }}:</strong> {{ form?.get(field.key!)?.value }}
+        </div>
+      </div>
+    </div>
+  </ng-container>
+
+  <ng-template #nonStepper>
+    <ng-container *ngIf="schema?.sections; else flat">
+      <ng-container *ngFor="let section of schema!.sections!">
+        <div *ngIf="isVisible(section.visibleIf)" nz-row [nzGutter]="section.grid?.gutter ?? 0">
+          <ng-container *ngFor="let field of visibleFields(section)">
+            <div nz-col *ngIf="field.type !== 'textblock'; else textBlock2">
+              <nz-form-item>
+                <nz-form-label [nzSpan]="schema?.ui?.labelCol?.span ?? null" [nzOffset]="schema?.ui?.labelCol?.offset ?? null" [nzRequired]="field.validators?.includes(Validators.required)">{{ field.label }}</nz-form-label>
+                <nz-form-control [nzSpan]="schema?.ui?.controlCol?.span ?? null" [nzOffset]="schema?.ui?.controlCol?.offset ?? null">
+                  <ng-container [ngSwitch]="field.type">
+                    <input *ngSwitchCase="'text'" nz-input [formControlName]="field.key!" [placeholder]="field.placeholder" />
+                    <textarea *ngSwitchCase="'textarea'" nz-input [formControlName]="field.key!" [placeholder]="field.placeholder"></textarea>
+                    <input *ngSwitchCase="'number'" nz-input type="number" [formControlName]="field.key!" [placeholder]="field.placeholder" />
+                    <nz-date-picker *ngSwitchCase="'date'" [formControlName]="field.key!" />
+                    <nz-select *ngSwitchCase="'select'" [formControlName]="field.key!">
+                      <nz-option *ngFor="let o of field.options" [nzLabel]="o.label" [nzValue]="o.value"></nz-option>
+                    </nz-select>
+                    <nz-radio-group *ngSwitchCase="'radio'" [formControlName]="field.key!">
+                      <label nz-radio *ngFor="let o of field.options" [nzValue]="o.value">{{ o.label }}</label>
+                    </nz-radio-group>
+                    <label *ngSwitchCase="'checkbox'" nz-checkbox [formControlName]="field.key!">{{ field.label }}</label>
+                  </ng-container>
+                  <div class="desc" *ngIf="field.description">{{ field.description }}</div>
+                </nz-form-control>
+              </nz-form-item>
+            </div>
+            <ng-template #textBlock2><div class="text-block" [innerHTML]="field.textHtml"></div></ng-template>
+          </ng-container>
+        </div>
+      </ng-container>
+    </ng-container>
+    <ng-template #flat>
+      <ng-container *ngFor="let field of schema?.fields">
+        <div nz-col *ngIf="field.type !== 'textblock'; else textBlock3">
+          <nz-form-item>
+            <nz-form-label [nzSpan]="schema?.ui?.labelCol?.span ?? null" [nzOffset]="schema?.ui?.labelCol?.offset ?? null" [nzRequired]="field.validators?.includes(Validators.required)">{{ field.label }}</nz-form-label>
+            <nz-form-control [nzSpan]="schema?.ui?.controlCol?.span ?? null" [nzOffset]="schema?.ui?.controlCol?.offset ?? null">
+              <ng-container [ngSwitch]="field.type">
+                <input *ngSwitchCase="'text'" nz-input [formControlName]="field.key!" [placeholder]="field.placeholder" />
+                <textarea *ngSwitchCase="'textarea'" nz-input [formControlName]="field.key!" [placeholder]="field.placeholder"></textarea>
+                <input *ngSwitchCase="'number'" nz-input type="number" [formControlName]="field.key!" [placeholder]="field.placeholder" />
+                <nz-date-picker *ngSwitchCase="'date'" [formControlName]="field.key!" />
+                <nz-select *ngSwitchCase="'select'" [formControlName]="field.key!">
+                  <nz-option *ngFor="let o of field.options" [nzLabel]="o.label" [nzValue]="o.value"></nz-option>
+                </nz-select>
+                <nz-radio-group *ngSwitchCase="'radio'" [formControlName]="field.key!">
+                  <label nz-radio *ngFor="let o of field.options" [nzValue]="o.value">{{ o.label }}</label>
+                </nz-radio-group>
+                <label *ngSwitchCase="'checkbox'" nz-checkbox [formControlName]="field.key!">{{ field.label }}</label>
+              </ng-container>
+              <div class="desc" *ngIf="field.description">{{ field.description }}</div>
+            </nz-form-control>
+          </nz-form-item>
+        </div>
+        <ng-template #textBlock3><div class="text-block" [innerHTML]="field.textHtml"></div></ng-template>
+      </ng-container>
+    </ng-template>
+  </ng-template>
+
+  <div class="buttons" *ngIf="schema?.steps">
+    <button nz-button nzType="default" (click)="prev()" [disabled]="currentStep === 0">Previous</button>
+    <button nz-button nzType="default" (click)="next()" *ngIf="currentStep < stepFieldKeys.length - 1" [disabled]="!isStepValid(currentStep)">Next</button>
+    <button nz-button nzType="primary" (click)="submit()" *ngIf="currentStep === stepFieldKeys.length - 1" [disabled]="!form?.valid">Submit</button>
+  </div>
+  <div class="buttons" *ngIf="!schema?.steps">
+    <button nz-button nzType="primary" (click)="submit()" [disabled]="!form?.valid">Submit</button>
+  </div>
+</form>

--- a/src/app/features/dynamic-form/dynamic-form.component.scss
+++ b/src/app/features/dynamic-form/dynamic-form.component.scss
@@ -1,0 +1,12 @@
+.text-block {
+  margin-bottom: 16px;
+}
+.buttons {
+  margin-top: 16px;
+  display: flex;
+  gap: 8px;
+}
+.desc {
+  font-size: 12px;
+  color: #888;
+}

--- a/src/app/features/dynamic-form/dynamic-form.component.ts
+++ b/src/app/features/dynamic-form/dynamic-form.component.ts
@@ -1,0 +1,125 @@
+import { CommonModule } from '@angular/common';
+import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { NzFormModule } from 'ng-zorro-antd/form';
+import { NzInputModule } from 'ng-zorro-antd/input';
+import { NzSelectModule } from 'ng-zorro-antd/select';
+import { NzRadioModule } from 'ng-zorro-antd/radio';
+import { NzCheckboxModule } from 'ng-zorro-antd/checkbox';
+import { NzDatePickerModule } from 'ng-zorro-antd/date-picker';
+import { NzGridModule } from 'ng-zorro-antd/grid';
+import { NzStepsModule } from 'ng-zorro-antd/steps';
+import { NzButtonModule } from 'ng-zorro-antd/button';
+import { NzTypographyModule } from 'ng-zorro-antd/typography';
+import { DynamicFormService } from './dynamic-form.service';
+import { FieldConfig, FormSchema, SectionConfig, StepConfig } from './dynamic-form.types';
+import { NgIf, NgFor, NgSwitch, NgSwitchCase, NgSwitchDefault } from '@angular/common';
+
+@Component({
+  selector: 'dynamic-form',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    NgIf,
+    NgFor,
+    NgSwitch,
+    NgSwitchCase,
+    NgSwitchDefault,
+    NzFormModule,
+    NzInputModule,
+    NzSelectModule,
+    NzRadioModule,
+    NzCheckboxModule,
+    NzDatePickerModule,
+    NzGridModule,
+    NzStepsModule,
+    NzButtonModule,
+    NzTypographyModule,
+  ],
+  templateUrl: './dynamic-form.component.html',
+  styleUrl: './dynamic-form.component.scss',
+})
+export class DynamicFormComponent implements OnChanges {
+  @Input() schema?: FormSchema;
+
+  form?: FormGroup;
+  readonly Validators = Validators;
+  currentStep = 0;
+  stepFieldKeys: string[][] = [];
+
+  constructor(private dfs: DynamicFormService) {}
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['schema'] && this.schema) {
+      this.form = this.dfs.buildForm(this.schema);
+      if (this.schema.steps) {
+        this.stepFieldKeys = this.schema.steps.map(step => this.collectFieldKeys(step));
+        if (this.schema.summary?.enabled) {
+          this.stepFieldKeys.push([]);
+        }
+      } else {
+        this.stepFieldKeys = [this.collectFieldKeys({ sections: this.schema.sections ?? [], visibleIf: undefined } as StepConfig)];
+        if (this.schema.summary?.enabled) {
+          this.stepFieldKeys.push([]);
+        }
+      }
+    }
+  }
+
+  collectFieldKeys(step: StepConfig): string[] {
+    const keys: string[] = [];
+    step.sections.forEach(sec => sec.fields?.forEach(f => f.key && keys.push(f.key)));
+    return keys;
+  }
+
+  isVisible(expr: any): boolean {
+    return this.dfs.evaluate(expr, this.form?.value ?? {});
+  }
+
+  isStepValid(index: number): boolean {
+    const keys = this.stepFieldKeys[index];
+    if (!this.form) {
+      return false;
+    }
+    return keys.every(key => {
+      const ctrl = this.form!.get(key);
+      return ctrl && ctrl.valid && !ctrl.pending;
+    });
+  }
+
+  next(): void {
+    if (this.currentStep < this.stepFieldKeys.length - 1) {
+      this.currentStep++;
+    }
+  }
+
+  prev(): void {
+    if (this.currentStep > 0) {
+      this.currentStep--;
+    }
+  }
+
+  submit(): void {
+    if (this.form?.valid) {
+      console.log(this.form.value);
+    }
+  }
+
+  visibleFields(section: SectionConfig): FieldConfig[] {
+    return (section.fields ?? []).filter(f => this.isVisible(f.visibleIf));
+  }
+
+  allFields(): FieldConfig[] {
+    const fields: FieldConfig[] = [];
+    const collect = (sections?: SectionConfig[]) => {
+      sections?.forEach(s => s.fields?.forEach(f => fields.push(f)));
+    };
+    if (this.schema?.steps) {
+      this.schema.steps.forEach(step => collect(step.sections));
+    }
+    collect(this.schema?.sections);
+    fields.push(...(this.schema?.fields ?? []));
+    return fields;
+  }
+}

--- a/src/app/features/dynamic-form/dynamic-form.service.ts
+++ b/src/app/features/dynamic-form/dynamic-form.service.ts
@@ -1,0 +1,85 @@
+import { Injectable } from '@angular/core';
+import { FormBuilder, FormControl, FormGroup } from '@angular/forms';
+import { FieldConfig, FormSchema, StepConfig } from './dynamic-form.types';
+
+@Injectable({ providedIn: 'root' })
+export class DynamicFormService {
+  constructor(private fb: FormBuilder) {}
+
+  buildForm(schema: FormSchema): FormGroup {
+    const group: Record<string, FormControl> = {};
+    const addField = (field: FieldConfig): void => {
+      if (!field.key) {
+        return;
+      }
+      const value = field.default ?? this.defaultValue(field.type);
+      const control = new FormControl(value, field.validators ?? []);
+      group[field.key] = control;
+    };
+
+    const walkFields = (fields?: FieldConfig[]): void => {
+      fields?.forEach(f => addField(f));
+    };
+
+    const walkSections = (sections?: any[]): void => {
+      sections?.forEach((s: any) => walkFields(s.fields));
+    };
+
+    if (schema.steps) {
+      schema.steps.forEach((step: StepConfig) => walkSections(step.sections));
+    }
+    walkSections(schema.sections);
+    walkFields(schema.fields);
+
+    return this.fb.group(group);
+  }
+
+  defaultValue(type: string): unknown {
+    switch (type) {
+      case 'text':
+      case 'textarea':
+        return '';
+      case 'checkbox':
+        return false;
+      case 'number':
+      case 'date':
+      case 'select':
+      case 'radio':
+        return null;
+      default:
+        return null;
+    }
+  }
+
+  evaluate(expr: any, values: any): boolean {
+    if (!expr) {
+      return true;
+    }
+    const op = Object.keys(expr)[0];
+    const args = expr[op];
+    switch (op) {
+      case 'var':
+        return values[args as string];
+      case '==':
+        return this.evaluate(args[0], values) === this.evaluate(args[1], values);
+      case '!=':
+        return this.evaluate(args[0], values) !== this.evaluate(args[1], values);
+      case '>':
+        return this.evaluate(args[0], values) > this.evaluate(args[1], values);
+      case '<':
+        return this.evaluate(args[0], values) < this.evaluate(args[1], values);
+      case '>=':
+        return this.evaluate(args[0], values) >= this.evaluate(args[1], values);
+      case '<=':
+        return this.evaluate(args[0], values) <= this.evaluate(args[1], values);
+      case 'all':
+        return args.every((a: any) => this.evaluate(a, values));
+      case 'any':
+        return args.some((a: any) => this.evaluate(a, values));
+      case 'not':
+        return !this.evaluate(args, values);
+      default:
+        return true;
+    }
+  }
+}

--- a/src/app/features/dynamic-form/dynamic-form.types.ts
+++ b/src/app/features/dynamic-form/dynamic-form.types.ts
@@ -1,0 +1,50 @@
+export type FieldType = 'text' | 'textarea' | 'number' | 'date' | 'select' | 'radio' | 'checkbox' | 'textblock';
+
+export interface FormUI {
+  layout?: 'horizontal' | 'vertical' | 'inline';
+  labelAlign?: 'left' | 'right';
+  labelCol?: { span?: number; offset?: number };
+  controlCol?: { span?: number; offset?: number };
+  widthPx?: number;
+}
+
+export interface BaseField {
+  type: FieldType;
+  label?: string;
+  placeholder?: string;
+  description?: string;
+  default?: unknown;
+  validators?: any[];
+  options?: { label: string; value: unknown }[];
+  visibleIf?: any;
+  requiredIf?: any;
+  disabledIf?: any;
+  col?: Partial<Record<'xs' | 'sm' | 'md' | 'lg' | 'xl', number>>;
+  textHtml?: string;
+  key?: string;
+}
+
+export type FieldConfig = BaseField;
+
+export interface SectionConfig {
+  title?: string;
+  description?: string;
+  grid?: { gutter?: number };
+  visibleIf?: any;
+  fields?: FieldConfig[];
+}
+
+export interface StepConfig {
+  title?: string;
+  visibleIf?: any;
+  sections: SectionConfig[];
+}
+
+export interface FormSchema {
+  title?: string;
+  ui?: FormUI;
+  steps?: StepConfig[];
+  sections?: SectionConfig[];
+  fields?: FieldConfig[];
+  summary?: { enabled?: boolean; title?: string; includeHidden?: boolean };
+}


### PR DESCRIPTION
## Summary
- add standalone DynamicForm component with schema-driven rendering and summary step
- create drag & drop DynamicFormBuilder with basic inspector and JSON import/export
- expose the builder at /dynamic-form and document usage

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `npm run build` *(fails: bundle initial exceeded maximum budget)*

------
https://chatgpt.com/codex/tasks/task_e_689b41f05ad8832fbf9f9c29943cb047